### PR TITLE
fix puppet 4 'case' statement and default detected profile in centos 7

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,7 +11,7 @@ class tuned::config (
   validate_absolute_path($_active_profile_fn)
 
   # if no profile specified, tuned will detect suitable
-  if $profile {
+  if ! empty($profile) {
     exec { 'tuned-adm_profile':
       command => shellquote('tuned-adm', 'profile', $profile),
       unless  => shellquote('grep', '-Fqx', $profile, $_active_profile_fn),
@@ -26,7 +26,7 @@ class tuned::config (
       notify  => Class['tuned::service'],
     }
 
-    if $profile {
+    if ! empty($profile) {
       Ini_setting {
         before => Exec['tuned-adm_profile'],
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class tuned::params {
 
     redhat,centos,scientific,oraclelinux: {
       case $::operatingsystemmajrelease {
-        6: {
+        '6': {
           $majversion = pick($_majversion, '0')
           $dynamic_tuning = false
           $main_conf = '' # unsupported
@@ -31,7 +31,7 @@ class tuned::params {
           $active_profile_conf = 'active-profile'
         }
 
-        7: {
+        '7': {
           $majversion = pick($_majversion, '2')
           $dynamic_tuning = false
           $main_conf = '/etc/tuned/tuned-main.conf'


### PR DESCRIPTION
-  fix case statement for string
  https://docs.puppet.com/puppet/latest/reference/lang_updating_manifests.html#regular-expressions-against-non-strings
- fix autodetect profile for centos 7 by default with skipping `tuned-adm` block if `profile` is empty as `tuned-adm profile ''` return error.
