### PR TITLE
Avoid automatic data type conversion issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Module has been tested on:
 
 Required modules:
 
-* stdlib (https://github.com/puppetlabs/puppetlabs-stdlib)
+* [stdlib](https://github.com/puppetlabs/puppetlabs-stdlib)
+* [puppetlabs-inifile](https://github.com/puppetlabs/puppetlabs-inifile)
 
 # Quick Start
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class tuned (
   validate_integer($sleep_interval, $update_interval)
   validate_absolute_path($profiles_path)
 
-  if $main_conf {
+  if !empty($main_conf) {
     validate_absolute_path($main_conf)
   }
 


### PR DESCRIPTION
Hello,

addressing #3, this module now also succeeds for us on Scientific Linux 6.8 again. Because we had not included puppetlabs-inifile in our stock of external modules, we also ran into an error due to the unknown resource type `ini_setting`. Therefore, I added this as a required module in the README (#4).

Please revise the changes.

Best regards,
Xavier.