### PR TITLE
Updated stdlib_requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 <= 5.2.0"
     },
     {
       "name": "puppetlabs/inifile",


### PR DESCRIPTION
Based on the changelog puppet-stdlib and a test-run on CentOS 7 including puppetlabs-stdilib 5.2.0. It also works up to and including puppet std-lib 5.2.0. 

https://forge.puppet.com/puppetlabs/stdlib/changelog
