### PR TITLE
Prevent undefined message error (fixes #14)

### DIFF
--- a/lib/facter/tuned.rb
+++ b/lib/facter/tuned.rb
@@ -10,7 +10,7 @@ Facter.add('tuned_version') do
     out = Facter::Core::Execution.exec('tuned --version 2>&1')
     if out && out =~ %r{^tuned ([\d\.]+)$}i
       Regexp.last_match(1)
-    elsif !Facter::Core::Execution.exec('which tuned 2>/dev/null').empty?
+    elsif Facter::Core::Execution.exec('which tuned 2>/dev/null')
       'unknown'
     end
   end


### PR DESCRIPTION
Remove empty? test
When this module is in the environment modules dir but not "included",
attempt to resolve fact "tuned_version" throws an error