### PR TITLE
Prevent nil return value error in custom fact

### DIFF
--- a/lib/facter/tuned.rb
+++ b/lib/facter/tuned.rb
@@ -10,8 +10,11 @@ Facter.add('tuned_version') do
     out = Facter::Core::Execution.exec('tuned --version 2>&1')
     if out && out =~ %r{^tuned ([\d\.]+)$}i
       Regexp.last_match(1)
-    elsif !Facter::Core::Execution.exec('which tuned 2>/dev/null').empty?
-      'unknown'
+    else
+      out = Facter::Core::Execution.exec('which tuned 2>/dev/null')
+      if ! out || out.empty?
+        'unknown'
+      end
     end
   end
 end


### PR DESCRIPTION
In certain situations (particularly during a kickstart build), the `tuned_version` fact errors out because tuned is not installed yet.  Therefore, it runs the `which tuned` exec, which fails.  However, it fails with a `nil` value instead of an empty string, so it throws a Ruby error, which keeps the catalog from compiling.