### PR TITLE
do not fail on an empty profile file

### DIFF
--- a/lib/facter/tuned.rb
+++ b/lib/facter/tuned.rb
@@ -33,7 +33,7 @@ Facter.add('tuned_profile') do
       ]
 
       alternatives.each do |fn|
-        if FileTest.exists?(fn)
+        if FileTest.exists?(fn) && !File.empty?(fn)
           result = File.foreach(fn).first.chomp
           break
         end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class tuned::params {
           $active_profile_conf = 'active-profile'
         }
 
-        /7|8/: {
+        /7|8|9/: {
           $majversion = pick($_majversion, '2')
           $dynamic_tuning = false
           $main_conf = '/etc/tuned/tuned-main.conf'


### PR DESCRIPTION
File.foreach() returns an array on nil ([nil]) on an empty file.

Make sure we don't fall over that one.