### PR TITLE
Update type compatibility with stdlib 9.x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@ class tuned (
   Integer $sleep_interval                                        = $tuned::params::sleep_interval,
   Integer $update_interval                                       = $tuned::params::update_interval,
   String $majversion                                             = $tuned::params::majversion,
-  Variant[Stdlib::Compat::Absolute_path, String[0,0]] $main_conf = $tuned::params::main_conf,
+  Variant[Stdlib::Absolutepath, String[0,0]] $main_conf          = $tuned::params::main_conf,
   Stdlib::Absolutepath $profiles_path                            = $tuned::params::profiles_path,
   String $active_profile_conf                                    = $tuned::params::active_profile_conf,
   Array[String, 1] $packages                                     = $tuned::params::packages,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@ class tuned::params {
   $sleep_interval = 1
   $update_interval = 10
 
-  if has_key($facts, 'tuned_version') and $facts['tuned_version'] =~ /^(\d+)\.[\d\.]+$/ {
+  if 'tuned_version' in $facts and $facts['tuned_version'] =~ /^(\d+)\.[\d\.]+$/ {
     $_majversion = $1
   } else {
     $_majversion = undef

--- a/manifests/profile/script.pp
+++ b/manifests/profile/script.pp
@@ -4,7 +4,7 @@ define tuned::profile::script (
   Hash[String, String] $scripts,
   Pattern[/^[\w\-\.]+$/] $script_name = $title,
 ) {
-  unless has_key($scripts, $script_name) {
+  unless $script_name in $scripts {
     fail("Missing content for script ${script_name}")
   }
 


### PR DESCRIPTION
This updates the type for `main_conf` to match that of `profiles_path` and the deprecated `has_key` funcction to enable updating to the latest stldib module.  This is due to several deprecated functions being removed (ref: https://github.com/puppetlabs/puppetlabs-stdlib/releases/tag/v9.0.0)