### PR TITLE
No quote wrapping for non-sysctl sections

### DIFF
--- a/templates/tuned.conf.epp
+++ b/templates/tuned.conf.epp
@@ -1,4 +1,7 @@
-<% | Hash[String[1], Hash[String[1],Variant[String[1],Numeric]]] $data | -%>
+<% | 
+  Hash[String[1], Hash[String[1],Variant[String[1],Numeric]]] $data,
+  Array[String[1]] $quoted_sections = ['sysctl'],
+| -%>
 #
 # tuned configuration managed by Puppet
 #
@@ -6,6 +9,6 @@
 
 [<%= $section %>]
 <% sort(keys($data[$section])).each |$key| { -%>
-<%= $key %>=<% if (' ' in $data[$section][$key]) { -%>"<%= $data[$section][$key] %>"<% } else { -%><%= $data[$section][$key] %><% } %>
+<%= $key %>=<% if (' ' in $data[$section][$key]) and ($section in $quoted_sections) { -%>"<%= $data[$section][$key] %>"<% } else { -%><%= $data[$section][$key] %><% } %>
 <% } -%>
 <% } -%>


### PR DESCRIPTION
Although quoting space-containing values in the `[sysctl]` section of a tuned profile is fine, arguably necessary, and shown in RedHat's included default tuning profiles, when our template adds quotes to all values in all sections, they are taken literally and included as if they were part of the value itself.  Adjust this quote-by-default logic in the profile template so that it only quotes values inside of the `[sysctl]` section, and nothing else.  It is still possible for anyone who needs literal quotes around a value outside of this section to pass them as part of Puppet's value, but the template will no longer add them.

This patch is tested, works correctly, and is in production on all ~3k of our hosts.  This resolves #28.